### PR TITLE
Ensure the same image version for postgress

### DIFF
--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -25,7 +25,7 @@ function run_db {
     -e POSTGRES_PASSWORD="$DATABASE_PASSWORD"  \
     -e POSTGRES_USER="$DATABASE_USER"  \
     -e POSTGRES_DB="$DATABASE_DB" \
-    -d postgres
+    -d postgres:9.5
 
     echo "Waiting for POSTGRES container to start..."
     sleep 5s


### PR DESCRIPTION
In its current state: Line 13 downloads postgress version 9:5. On the other hand, lines 24-28 forces the dowload of another version of postgress (latest is currently 10.1).

To avoid downloading two images: either force a specific version like 9.5 or explicit set to latest in both cases.
Moreover, line 13 can be ommited, as line 24 will download it anyway.